### PR TITLE
Updates for TMX and bug fix

### DIFF
--- a/tmdrv.py
+++ b/tmdrv.py
@@ -21,7 +21,7 @@ import argparse
 import tmdrv_devices
 import usb1
 from importlib import import_module
-from subprocess import check_call
+from subprocess import check_call, CalledProcessError
 
 device_list = ['thrustmaster_tx', 'thrustmaster_tmx', 'thrustmaster_t500rs']
 
@@ -79,7 +79,7 @@ def _jscal(configuration, device_file):
 		check_call(['jscal', '-s', configuration, device_file])
 	except FileNotFoundError:
 		print("jscal not found, skipping device calibration.")
-	except subprocess.CalledProcessError as err:
+	except CalledProcessError as err:
 		print("jscal non-zero exit code {}, device may not be calibrated".format(str(err)[-1]))
 
 def _control_init(idVendor, idProduct, request_type, request, value, index, data):

--- a/tmdrv_devices/thrustmaster_tmx.py
+++ b/tmdrv_devices/thrustmaster_tmx.py
@@ -1,9 +1,9 @@
 name = 'Thrustmaster TMX'
 idVendor = 0x044f
-idProduct = [ 0xb65d, 0xb67e]
+idProduct = [0xb67e, 0xb65d, 0xb67f]
 control = [
 	{'step':1, 'request_type':0x41, 'request':83, 'value':0x0001, 'index':0x0000, 'data':b''},
-	{'step':2, 'request_type':0x41, 'request':83, 'value':0x0004, 'index':0x0000, 'data':b''},
+	{'step':2, 'request_type':0x41, 'request':83, 'value':0x0007, 'index':0x0000, 'data':b''},
 ]
 jscal = '6,1,255,32767,32767,21844,21844,1,3,511,511,1394469,1394469,1,3,511,511,1394469,1394469,1,3,511,511,1394469,1394469,1,0,0,0,536870912,536870912,1,0,0,0,536870912,536870912'
 dev_by_id = 'usb-Thrustmaster_Thrustmaster_TMX_Racing_Wheel-joystick'


### PR DESCRIPTION
- Updated device id and step 2 initialization as described in change request to be in line with pcap data
- Fixed a bug that caused tmxdrv.py to crash if jscal could not get
permissions to a joy device.